### PR TITLE
Add batching jobs

### DIFF
--- a/src/Benchmark.php
+++ b/src/Benchmark.php
@@ -31,22 +31,22 @@ class Benchmark
         }, $this->samples);
     }
 
-    public function run(int $interactions) : array
+    public function run(int $interactions, int $batchCount) : array
     {
         $this->warmup();
-        $this->doRun($interactions);
+        $this->doRun($interactions, $batchCount);
 
         return $this->results;
     }
 
-    private function doRun(int $interactions)
+    private function doRun(int $interactions, int $batchCount)
     {
         foreach ($this->samples as $sample) {
             $stopwatch = new Stopwatch();
 
             $stopwatch->start('interaction');
             for ($i = 0; $i < $interactions; $i++) {
-                $sample->run($i);
+                $sample->run($i, $batchCount);
                 $stopwatch->lap('interaction');
             }
             $intEvent = $stopwatch->stop('interaction');

--- a/src/BenchmarkSample.php
+++ b/src/BenchmarkSample.php
@@ -32,6 +32,6 @@ namespace TSantos\Benchmark;
 abstract class BenchmarkSample
 {
     abstract public function getName() : string;
-    abstract public function run(?int $iteration = 0);
+    abstract public function run(?int $iteration = 0, ?int $batchCount = 1);
     abstract public function verify($result);
 }

--- a/src/Console/Command/DeserializeCommand.php
+++ b/src/Console/Command/DeserializeCommand.php
@@ -28,6 +28,7 @@ class DeserializeCommand extends Command
             ->setName('deserialize')
             ->setDescription('Benchmarks the deserialization process')
             ->addOption('interactions', 'i', InputOption::VALUE_REQUIRED, 'Amount of deserialization each vendor will perform', 100)
+            ->addOption('batch-count', 'b', InputOption::VALUE_REQUIRED, 'Quantity of objects per each deserialization', 1)
             ->addOption('exclude', 'e', InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Exclude a vendor from benchmark');
     }
 
@@ -53,11 +54,12 @@ class DeserializeCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $interactions = $input->getOption('interactions');
+        $batchCount = $input->getOption('batch-count');
 
         $style = new SymfonyStyle($input, $output);
-        $style->title(sprintf('Performing <info>%d</info> deserialization interactions', $interactions));
+        $style->title(sprintf('Performing <info>%d</info> deserialization interactions, <info>%d</info> objects each', $interactions, $batchCount));
 
-        $result = $this->benchmark->run($interactions);
+        $result = $this->benchmark->run($interactions, $batchCount);
 
         $style->table(['vendor', 'duration (ms)', 'memory (MiB)'], $this->getHelper('result')->sort($result));
     }

--- a/src/Console/Command/SerializeCommand.php
+++ b/src/Console/Command/SerializeCommand.php
@@ -29,6 +29,7 @@ class SerializeCommand extends Command
             ->setName('serialize')
             ->setDescription('Benchmarks the serialization process')
             ->addOption('interactions', 'i', InputOption::VALUE_REQUIRED, 'Amount of serializations each vendor will perform', 100)
+            ->addOption('batch-count', 'b', InputOption::VALUE_REQUIRED, 'Quantity of objects per each serialization', 1)
             ->addOption('exclude', 'e', InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Exclude a vendor from benchmark');
     }
 
@@ -58,11 +59,12 @@ class SerializeCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $interactions = $input->getOption('interactions');
+        $batchCount = $input->getOption('batch-count');
 
         $style = new SymfonyStyle($input, $output);
-        $style->title(sprintf('Performing <info>%d</info> serialization interactions', $interactions));
+        $style->title(sprintf('Performing <info>%d</info> serialization interactions, <info>%d</info> objects each', $interactions, $batchCount));
 
-        $result = $this->benchmark->run($interactions);
+        $result = $this->benchmark->run($interactions, $batchCount);
 
         $style->table(['vendor', 'duration (ms)', 'memory (MiB)'], $this->getHelper('result')->sort($result));
     }

--- a/src/Serialize/SerializeBenchmarkSample.php
+++ b/src/Serialize/SerializeBenchmarkSample.php
@@ -32,21 +32,25 @@ abstract class SerializeBenchmarkSample extends BenchmarkSample
     abstract protected function serialize($object) : string;
     abstract protected function getSampleName() : string;
 
-    public function run(?int $iteration = 0) : string
+    public function run(?int $iteration = 0, ?int $batchCount = 1) : string
     {
-        $person = (new Person())
-            ->setId($iteration)
-            ->setName('Foo ')
-            ->setMarried(true)
-            ->setFavoriteColors(['blue', 'red'])
-            ->setMother((new Person())
+        $persons = [];
+        for ($i = 0; $i < $batchCount; $i++) {
+            $persons[] = (new Person())
                 ->setId($iteration)
-                ->setName('Foo\'s mother')
-                ->setMarried(false)
-                ->setFavoriteColors(['blue', 'violet'])
-            );
+                ->setName('Foo ')
+                ->setMarried(true)
+                ->setFavoriteColors(['blue', 'red'])
+                ->setMother(
+                    (new Person())
+                        ->setId($iteration)
+                        ->setName('Foo\'s mother')
+                        ->setMarried(false)
+                        ->setFavoriteColors(['blue', 'violet'])
+                );
+        }
 
-        return $this->serialize($person);
+        return $this->serialize($batchCount === 1 ? reset($persons) : $persons);
     }
 
     public function verify($result)

--- a/src/Serialize/SymfonySample.php
+++ b/src/Serialize/SymfonySample.php
@@ -41,7 +41,7 @@ class SymfonySample extends SerializeBenchmarkSample
 
     protected function serialize($object) : string
     {
-        return $this->serializer->serialize($object, 'json');
+        return (string) $this->serializer->serialize($object, 'json');
     }
 
     public function getSampleName() : string

--- a/src/Unserialize/JmsSample.php
+++ b/src/Unserialize/JmsSample.php
@@ -45,7 +45,7 @@ class JmsSample extends UnserializeBenchmarkSample
 
     protected function unserialize(string $json)
     {
-        return $this->serializer->deserialize($json, Person::class, 'json');
+        return $this->serializer->deserialize($json, 'array<' . Person::class . '>', 'json');
     }
 
     public function getSampleName() : string

--- a/src/Unserialize/SimpleSerializerSample.php
+++ b/src/Unserialize/SimpleSerializerSample.php
@@ -48,7 +48,7 @@ class SimpleSerializerSample extends UnserializeBenchmarkSample
 
     protected function unserialize(string $json)
     {
-        return $this->serializer->unserialize($json, new Person());
+        return $this->serializer->unserialize($json, [new Person()]);
     }
 
     public function getSampleName() : string

--- a/src/Unserialize/Symfony/PersonDenormalizer.php
+++ b/src/Unserialize/Symfony/PersonDenormalizer.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+/**
+ * Copyright (C) 2017 Eduard Sukharev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace TSantos\Benchmark\Unserialize\Symfony;
+
+use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\ExtraAttributesException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use TSantos\Benchmark\Person;
+
+class PersonDenormalizer implements DenormalizerInterface
+{
+    /**
+     * Denormalizes data back into an object of the given class.
+     *
+     * @param mixed $data Data to restore
+     * @param string $class The expected class to instantiate
+     * @param string $format Format the given data was extracted from
+     * @param array $context Options available to the denormalizer
+     *
+     * @return object
+     *
+     * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
+     * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported
+     * @throws UnexpectedValueException Occurs when the item cannot be hydrated with the given data
+     * @throws ExtraAttributesException Occurs when the item doesn't have attribute to receive given data
+     * @throws LogicException           Occurs when the normalizer is not supposed to denormalize
+     * @throws RuntimeException         Occurs if the class cannot be instantiated
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $person = new Person();
+
+        if (array_key_exists('id', $data)) {
+            $person->setId($data['id']);
+        }
+        if (array_key_exists('name', $data)) {
+            $person->setName($data['name']);
+        }
+        if (array_key_exists('married', $data)) {
+            $person->setMarried($data['married']);
+        }
+        if (array_key_exists('favoriteColors', $data)) {
+            $person->setFavoriteColors($data['favoriteColors']);
+        }
+        if (isset($data['mother'])) {
+            $person->setMother($this->denormalize($data['mother'], $class, $format, $context));
+        }
+
+        return $person;
+    }
+
+    /**
+     * Checks whether the given class is supported for denormalization by this normalizer.
+     *
+     * @param mixed $data Data to denormalize from
+     * @param string $type The class to which the data should be denormalized
+     * @param string $format The format being deserialized from
+     *
+     * @return bool
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === Person::class;
+    }
+}

--- a/src/Unserialize/SymfonySample.php
+++ b/src/Unserialize/SymfonySample.php
@@ -25,9 +25,10 @@ declare(strict_types=1);
 namespace TSantos\Benchmark\Unserialize;
 
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Serializer;
 use TSantos\Benchmark\Person;
+use TSantos\Benchmark\Unserialize\Symfony\PersonDenormalizer;
 
 class SymfonySample extends UnserializeBenchmarkSample
 {
@@ -36,13 +37,13 @@ class SymfonySample extends UnserializeBenchmarkSample
     public function __construct()
     {
         $encoders = array(new JsonEncoder());
-        $normalizers = array(new ObjectNormalizer());
+        $normalizers = array(new PersonDenormalizer(), new ArrayDenormalizer());
         $this->serializer = new Serializer($normalizers, $encoders);
     }
 
     protected function unserialize(string $json)
     {
-        return $this->serializer->deserialize($json, Person::class, 'json');
+        return $this->serializer->deserialize($json, Person::class.'[]', 'json');
     }
 
     public function getSampleName() : string


### PR DESCRIPTION
This adds `--batch-count` or `-b` option to control how many objects are to be serialized-deserialized per one iteration.
Since Symfony is not able to deserialize arrays of complex objects one has to [implement one's own Denormalizer per each domain object](https://thomas.jarrand.fr/blog/serialization/). That's kind of cheating, performance-wise, but it's a real-world use-case, which means it's official and simplest way to achieve the goal. This also fixes assertion failure for Symfony deserialization.