### PR TITLE
Added regular Symfony sample alongside with custom denormalizer one

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Sadly, TSantos serializer is only capable of serialization and has no means of d
 | Vendor            | 10 Obj.| 100 Obj. | 1k Obj. | 10k Obj. |
 |-------------------|--------|----------|---------|----------|
 | JMS               | 0.64   | 4.28     | 41.16   | 459.64   |
-| Symfony*          | 0.1    | 0.84     | 10.59   | 154.41   |
+| Symfony           | 0.55   | 3.84     | 36.61   | 444.28   |
+| Symfony (custom)* | 0.1    | 0.84     | 10.59   | 154.41   |
 | SimpleSerializer  | 0.12   | 0.59     | 6.57    | 96.85    |
 
 * Symfony serializer handles complex object quite poorly with default denormalizers, so creating a custom denormalizer,

--- a/src/Console/Command/DeserializeCommand.php
+++ b/src/Console/Command/DeserializeCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TSantos\Benchmark\Unserialize\JmsSample;
 use TSantos\Benchmark\Unserialize\SimpleSerializerSample;
+use TSantos\Benchmark\Unserialize\SymfonyCustomDenormalizerSample;
 use TSantos\Benchmark\Unserialize\SymfonySample;
 use TSantos\Benchmark\Benchmark;
 
@@ -44,6 +45,10 @@ class DeserializeCommand extends Command
 
         if (!in_array('symfony', $excludes)) {
             $this->benchmark->addSample(new SymfonySample());
+        }
+
+        if (!in_array('symfony-custom', $excludes)) {
+            $this->benchmark->addSample(new SymfonyCustomDenormalizerSample());
         }
 
         if (!in_array('simple_serializer', $excludes)) {

--- a/src/Unserialize/SymfonyCustomDenormalizerSample.php
+++ b/src/Unserialize/SymfonyCustomDenormalizerSample.php
@@ -26,19 +26,18 @@ namespace TSantos\Benchmark\Unserialize;
 
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
-use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use TSantos\Benchmark\Person;
 use TSantos\Benchmark\Unserialize\Symfony\PersonDenormalizer;
 
-class SymfonySample extends UnserializeBenchmarkSample
+class SymfonyCustomDenormalizerSample extends UnserializeBenchmarkSample
 {
     protected $serializer;
 
     public function __construct()
     {
         $encoders = array(new JsonEncoder());
-        $normalizers = array(new ObjectNormalizer(), new ArrayDenormalizer());
+        $normalizers = array(new PersonDenormalizer(), new ArrayDenormalizer());
         $this->serializer = new Serializer($normalizers, $encoders);
     }
 
@@ -49,6 +48,6 @@ class SymfonySample extends UnserializeBenchmarkSample
 
     public function getSampleName() : string
     {
-        return 'symfony';
+        return 'symfony (custom normalizer)';
     }
 }


### PR DESCRIPTION
Just figured out that Symfony serializer is able to unserialize JSON to objects even without custom-fitted denormalizers. This, however, creates objects that somewhat fail the verification - the `mother` object has it's own `mother`, although filled with **null**s, but for the demonstration purposes we can ignore it.

This "regular magic" of Symfony ObjectNormalizer demonstrates how slow uncustomized Symfony serializer can be, compared to the same Symfony Serializer with denormalizer, which is written for each domain object.