### PR TITLE
Added relative duration metrics

### DIFF
--- a/src/Console/Command/DeserializeCommand.php
+++ b/src/Console/Command/DeserializeCommand.php
@@ -66,6 +66,6 @@ class DeserializeCommand extends Command
 
         $result = $this->benchmark->run($samples, $batchCount);
 
-        $style->table(['vendor', 'duration (ms)'], $this->getHelper('result')->sort($result));
+        $style->table(['vendor', 'duration (ms)', 'duration, % of total', 'duration, % of fastest', 'duration, % of slowest'], $this->getHelper('result')->sort($result));
     }
 }

--- a/src/Console/Command/DeserializeCommand.php
+++ b/src/Console/Command/DeserializeCommand.php
@@ -66,6 +66,6 @@ class DeserializeCommand extends Command
 
         $result = $this->benchmark->run($samples, $batchCount);
 
-        $style->table(['vendor', 'duration (ms)', 'duration, % of total', 'duration, % of fastest', 'duration, % of slowest'], $this->getHelper('result')->sort($result));
+        $style->table(['vendor', 'duration (ms)', 'relative to fastest, %'], $this->getHelper('result')->sort($result));
     }
 }

--- a/src/Console/Command/SerializeCommand.php
+++ b/src/Console/Command/SerializeCommand.php
@@ -66,6 +66,6 @@ class SerializeCommand extends Command
 
         $result = $this->benchmark->run($samples, $batchCount);
 
-        $style->table(['vendor', 'duration (ms)', 'duration, % of total', 'duration, % of fastest', 'duration, % of slowest'], $this->getHelper('result')->sort($result));
+        $style->table(['vendor', 'duration (ms)', 'relative to fastest, %'], $this->getHelper('result')->sort($result));
     }
 }

--- a/src/Console/Command/SerializeCommand.php
+++ b/src/Console/Command/SerializeCommand.php
@@ -66,6 +66,6 @@ class SerializeCommand extends Command
 
         $result = $this->benchmark->run($samples, $batchCount);
 
-        $style->table(['vendor', 'duration (ms)'], $this->getHelper('result')->sort($result));
+        $style->table(['vendor', 'duration (ms)', 'duration, % of total', 'duration, % of fastest', 'duration, % of slowest'], $this->getHelper('result')->sort($result));
     }
 }

--- a/src/Console/Helper/ResultHelper.php
+++ b/src/Console/Helper/ResultHelper.php
@@ -35,12 +35,29 @@ class ResultHelper implements HelperInterface
         $rows = [];
 
         /** @var StopwatchEvent $event */
+        $fastestDuration = 999999;
+        $slowestDuration = 0;
+        $totalDuration = 0;
         foreach ($result as $vendor => $event) {
             $averageDuration = round($event->getDuration() / count($event->getPeriods()), 2);
+            $totalDuration += $averageDuration;
+
+            if ($averageDuration < $fastestDuration) {
+                $fastestDuration = $averageDuration;
+            }
+            if ($averageDuration > $slowestDuration) {
+                $slowestDuration = $averageDuration;
+            }
             $rows[$vendor] = [
                 'vendor' => $vendor,
                 'duration' => $averageDuration,
             ];
+        }
+        /** @var StopwatchEvent $event */
+        foreach ($result as $vendor => $event) {
+            $rows[$vendor]['durationFractionOfTotal'] = round(($rows[$vendor]['duration'] / $totalDuration) * 100, 2);
+            $rows[$vendor]['durationFractionOfFastest'] = round(($rows[$vendor]['duration'] / $fastestDuration) * 100, 2);
+            $rows[$vendor]['durationFractionOfSlowest'] = round(($rows[$vendor]['duration'] / $slowestDuration) * 100, 2);
         }
 
         usort($rows, function ($row1, $row2) {

--- a/src/Console/Helper/ResultHelper.php
+++ b/src/Console/Helper/ResultHelper.php
@@ -36,17 +36,11 @@ class ResultHelper implements HelperInterface
 
         /** @var StopwatchEvent $event */
         $fastestDuration = 999999;
-        $slowestDuration = 0;
-        $totalDuration = 0;
         foreach ($result as $vendor => $event) {
             $averageDuration = round($event->getDuration() / count($event->getPeriods()), 2);
-            $totalDuration += $averageDuration;
 
             if ($averageDuration < $fastestDuration) {
                 $fastestDuration = $averageDuration;
-            }
-            if ($averageDuration > $slowestDuration) {
-                $slowestDuration = $averageDuration;
             }
             $rows[$vendor] = [
                 'vendor' => $vendor,
@@ -55,9 +49,7 @@ class ResultHelper implements HelperInterface
         }
         /** @var StopwatchEvent $event */
         foreach ($result as $vendor => $event) {
-            $rows[$vendor]['durationFractionOfTotal'] = round(($rows[$vendor]['duration'] / $totalDuration) * 100, 2);
-            $rows[$vendor]['durationFractionOfFastest'] = round(($rows[$vendor]['duration'] / $fastestDuration) * 100, 2);
-            $rows[$vendor]['durationFractionOfSlowest'] = round(($rows[$vendor]['duration'] / $slowestDuration) * 100, 2);
+            $rows[$vendor]['durationFraction'] = round(($rows[$vendor]['duration'] / $fastestDuration) * 100, 2) - 100;
         }
 
         usort($rows, function ($row1, $row2) {

--- a/src/Unserialize/SymfonySample.php
+++ b/src/Unserialize/SymfonySample.php
@@ -29,7 +29,6 @@ use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use TSantos\Benchmark\Person;
-use TSantos\Benchmark\Unserialize\Symfony\PersonDenormalizer;
 
 class SymfonySample extends UnserializeBenchmarkSample
 {
@@ -50,5 +49,29 @@ class SymfonySample extends UnserializeBenchmarkSample
     public function getSampleName() : string
     {
         return 'symfony';
+    }
+
+    /**
+     * Symfony serializer creates an object initialized with nulls if it was given null,
+     * thus `parent` field is not null here
+     *
+     * @param $objects
+     */
+    public function verify($objects)
+    {
+        $object = reset($objects);
+        assert(get_class($object) === Person::class, $this->getName());
+        /** @var Person $object */
+        assert($object->getId() === 0, $this->getName());
+        assert($object->getName() === 'Foo ', $this->getName());
+        assert($object->isMarried() === true, $this->getName());
+        assert($object->getFavoriteColors() === ['blue', 'red'], $this->getName());
+        assert(is_object($mother = $object->getMother()), $this->getName());
+        assert($mother->getId() === $object->getId(), $this->getName());
+        assert($mother->getName() === 'Foo\'s mother', $this->getName());
+        assert($mother->getMarried() === false, $this->getName());
+        assert($mother->getFavoriteColors() === ['blue', 'violet'], $this->getName());
+
+        assert($mother->getMother() instanceof Person, $this->getName());
     }
 }

--- a/src/Unserialize/UnserializeBenchmarkSample.php
+++ b/src/Unserialize/UnserializeBenchmarkSample.php
@@ -71,7 +71,6 @@ JSON;
         assert($mother->getName() === 'Foo\'s mother', $this->getName());
         assert($mother->getMarried() === false, $this->getName());
         assert($mother->getFavoriteColors() === ['blue', 'violet'], $this->getName());
-        assert($mother->getMother() === null, $this->getName()); // Symfony serializer sets an object with nulls
     }
 
     final public function getName() : string


### PR DESCRIPTION
Relative duration metrics are taken as a fraction of total samples time (not total benchmark time, but a total of all average for each benchmark sample), a fraction of slowest benchmark sample (essentially, showing how much faster all the other samples are, in % to the slowest one), and a fraction of fastest benchmark sample (showing how much slower, in % to the fastest one, all other samples are).

@tsantos84 waiting for your thought on whether some of these metrics are at least meaningful or anyhow useful. My thoughts are that they might provide more reliable reference metrics — percentage of the total shouldn't change significantly on different machines.

![image](https://user-images.githubusercontent.com/3235378/33427481-778753cc-d5d6-11e7-9f15-fb0dea958526.png)
